### PR TITLE
Added MongoEngine's GeoPointField to the resource

### DIFF
--- a/tastypie_mongoengine/resources.py
+++ b/tastypie_mongoengine/resources.py
@@ -119,11 +119,13 @@ class MongoEngineResource(resources.ModelResource):
             result = tastypie_fields.IntegerField
         elif f.__class__.__name__ in ('FileField', 'BinaryField'):
             result = tastypie_fields.FileField
-        elif f.__class__.__name__ in ('DictField'):
+        elif f.__class__.__name__ in ('DictField',):
             result = tastypie_fields.DictField
-        elif f.__class__.__name__ in ('ListField'):
+        elif f.__class__.__name__ in ('ListField',):
             result = tastypie_fields.ListField
-        elif f.__class__.__name__ in ('ObjectIdField'):
+        elif f.__class__.__name__ in ('GeoPointField',):
+            result = tastypie_fields.ListField
+        elif f.__class__.__name__ in ('ObjectIdField',):
             result = fields.ObjectId
 
         return result


### PR DESCRIPTION
If the GeoPoint field is not handled as a ListField, the /schema/ endpoint incorrectly reports the datatype as "string".  The proper data type of a point is a list of two numeric elements.  This commit fixes that.
