### PR TITLE
embedded document schema tests

### DIFF
--- a/tests/test_project/test_app/tests/test_basic.py
+++ b/tests/test_project/test_app/tests/test_basic.py
@@ -1521,3 +1521,19 @@ class BasicTest(test_runner.MongoEngineTestCase):
 
         self.assertEqual(response['tzdt']['dt'], '2012-12-12T12:12:12')
         self.assertEqual(response['tzdt']['tz'], 'UTC')
+
+    def test_comment_schema(self):
+        uri = self.resourceListURI('embeddedcomment') + 'schema/'
+        response = self.c.get(uri)
+        self.assertEqual(response.status_code, 200)
+
+    def test_post_schema(self):
+        uri = self.resourceListURI('embeddedpost') + 'schema/'
+        response = self.c.get(uri)
+        self.assertEqual(response.status_code, 200)
+
+    def test_board_schema(self):
+        uri = self.resourceListURI('board') + 'schema/'
+        response = self.c.get(uri)
+        self.assertEqual(response.status_code, 200)
+

--- a/tests/test_project/urls.py
+++ b/tests/test_project/urls.py
@@ -30,6 +30,8 @@ v1_api.register(resources.ExporterResource())
 v1_api.register(resources.PipeResource())
 v1_api.register(resources.BlankableParentResource())
 v1_api.register(resources.ReadonlyParentResource())
+v1_api.register(resources.EmbeddedCommentResource())
+v1_api.register(resources.EmbeddedPostResource())
 
 urlpatterns = patterns('',
     url(r'^api/', include(v1_api.urls)),


### PR DESCRIPTION
I added a few tests to test_basic.py and exposed the appropriate resources in urls.py. Again, I'm not sure if your original intent was to allow EmbeddedDocuments' schema to be exposed, but it did work in 0.3 and not in 0.4.

My use case is that I'm providing nested forms to enter information into documents with embedded documents. I am using the schema to drive the form display by providing field names, whether the field is required, field type, etc. Without the schema available, if the embedded list field is empty, there is no way to know the embedded document structure.
