### PR TITLE
Filter support for polymorphic resources

### DIFF
--- a/tastypie_mongoengine/resources.py
+++ b/tastypie_mongoengine/resources.py
@@ -4,6 +4,7 @@ from django.conf import urls
 from django.core import exceptions, urlresolvers
 from django.db.models import base as models_base
 from django.utils import datastructures
+from bson import ObjectId
 
 try:
     # Django 1.5+
@@ -67,13 +68,31 @@ class ListQuerySet(datastructures.SortedDict):
 
         for field, value in kwargs.iteritems():
             value = self._process_filter_value(value)
-            if constants.LOOKUP_SEP in field:
-                raise tastypie_exceptions.InvalidFilterError("Unsupported filter: (%s, %s)" % (field, value))
-
             try:
-                result = ListQuerySet([(unicode(obj.pk), obj) for obj in result.itervalues() if getattr(obj, field) == value])
+                if constants.LOOKUP_SEP in field:
+                    filter_bits = field.split(constants.LOOKUP_SEP)
+                    field_name = filter_bits.pop(0)
+                    filter_type = 'exact'
+            except AttributeError, e:
+                raise tastypie_exceptions.InvalidFilterError("Unsupported filter: (%s, %s)" % (field, value))
+            try:
+                if isinstance(getattr(result[0], field_name), ObjectId):
+                    result = ListQuerySet([(unicode(obj.pk), obj) for obj in result.itervalues() if getattr(obj, field_name).__str__() == value])
+                else:
+                    result = ListQuerySet([(unicode(obj.pk), obj) for obj in result.itervalues() if getattr(obj, field_name) == value]  )
             except AttributeError, e:
                 raise tastypie_exceptions.InvalidFilterError(e)
+
+
+        # for field, value in kwargs.iteritems():
+        #     value = self._process_filter_value(value)
+        #     if constants.LOOKUP_SEP in field:
+        #         raise tastypie_exceptions.InvalidFilterError("Unsupported filter: (%s, %s)" % (field, value))
+
+        #     try:
+        #         result = ListQuerySet([(unicode(obj.pk), obj) for obj in result.itervalues() if getattr(obj, field) == value])
+        #     except AttributeError, e:
+        #         raise tastypie_exceptions.InvalidFilterError(e)
 
         return result
 


### PR DESCRIPTION
This is filter support for Polymorphic resource.
Following is the example when this fix works.
need support for oid and type filtering for below example.
Eg ::

```
class aResource(MongoEngineResource):
  ......
class bResource(MongoEngineResource):
  .......

class cResource(MongoEngineResource):
  class Meta:
    object_class = c
    polymorphic = {
        'c' : 'self',
        'a' : aResource,
        'b' : bResource,
    }
    filtering = {
         'oid' : ALL,
         'type' : ALL,
         'status' : ALL_WITH_RELATIONS,
    }

class dResource(MongoEngineResource):
  class Meta:
    queryset = d
  polyresouce = tastypie_mongoengine.fields.EmbeddedListField(of='cResourcee', attribute='polyresource', full=True, null=True)
```
