### PR TITLE
Allow versions of MongoEngne greater than 0.8.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
         install_requires = (
             'Django>=1.4',
             'django-tastypie>=0.9.12,<=0.10.0',
-            'mongoengine>=0.8.1,<0.8.2',
+            'mongoengine>=0.8.1',
             'python-dateutil>=2.1',
             'lxml',
             'defusedxml',
@@ -49,7 +49,7 @@ if __name__ == '__main__':
         tests_require = (
             'Django>=1.4',
             'django-tastypie>=0.9.12,<=0.10.0',
-            'mongoengine>=0.8.1,<0.8.2',
+            'mongoengine>=0.8.1',
             'python-dateutil>=2.1',
             'lxml',
             'defusedxml',


### PR DESCRIPTION
I'm not able to use django-tastypie-mongoengine because it presently limits the maximum version of MongoEngine to 0.8.1. This allows it to use any version of MongoEngine >= 0.8.1.
