### PR TITLE
BUGFIX: The 'attribute' argument of EmbeddedListField was ignored.

### DIFF
--- a/tastypie_mongoengine/fields.py
+++ b/tastypie_mongoengine/fields.py
@@ -231,7 +231,7 @@ class EmbeddedListField(BuildRelatedMixin, fields.ToManyField):
             self._to_class_with_listresource = type(base.__name__, (base, resources.MongoEngineListResource), {
                 '__module__': base.__module__,
                 '_parent': self._resource,
-                'attribute': self.instance_name,
+                'attribute': self.attribute or self.instance_name,
             })
         return self._to_class_with_listresource
 


### PR DESCRIPTION
The 'attribute' argument of EmbeddedListField was ignored.

For example, in the following situation:

class UserResource(resources.MongoEngineResource):

```
children = fields.EmbeddedListField(
    of=WishResource,
    attribute='childList',
    full=True,
    null=True
)
```

This will try to acces the 'children' attribute instead of 'childList'.
