### PR TITLE
Django 1.9 quick fix

### DIFF
--- a/tastypie_mongoengine/resources.py
+++ b/tastypie_mongoengine/resources.py
@@ -5,7 +5,7 @@ import sys
 from django.conf import urls
 from django.core import exceptions, urlresolvers
 from django.db.models import base as models_base
-from django.utils import datastructures
+from collections import OrderedDict
 
 try:
     # Django 1.5+
@@ -51,7 +51,7 @@ class NOT_HYDRATED(object):
     pass
 
 
-class ListQuerySet(datastructures.SortedDict):
+class ListQuerySet(OrderedDict):
     # Workaround for https://github.com/toastdriven/django-tastypie/pull/670
     query = Query()
 


### PR DESCRIPTION
In Django 1.9 django.utils.datastructures.SortedDict is removed; it is deprecated in Django 1.7.x. 
The first change replaces SortedDict with collections.OrderedDict from the Python standard library.